### PR TITLE
Lock Dredd at version 12

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -81,7 +81,7 @@ jobs:
         composer install --no-ansi --no-interaction --no-suggest --no-progress --prefer-dist
     - name: Install Dredd
       run: |
-        npm install dredd --no-optional
+        npm install dredd@12 --no-optional
     - name: Specification tests
       env:
         ADGANGSPLATFORMEN_DRIVER: testing

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ API specification tests are done by generating requests as documented
 by the specification and testing if the application reacts as
 documented. [Dredd](https://dredd.org/en/latest/) is used for this.
 
-To install Dredd, run: `npm install --global dredd`.
+To install Dredd, run: `npm install --global dredd@12`.
 
 Running Dredd is as simple as `dredd`. Dredd is configured to run
 `php -S 0.0.0.0:8080 -t public` to start the server, which simply runs the


### PR DESCRIPTION
For some reason our tests start failing from version 12 and on. See #1 for an example.

We have implemented [the same lock for the material list service](https://github.com/danskernesdigitalebibliotek/ddb-material-list/commit/372c1280556964ee1ddcb4cb0f8780f95005edd0).