### PR TITLE
5152 fix add searh

### DIFF
--- a/app/Http/Controllers/SearchesController.php
+++ b/app/Http/Controllers/SearchesController.php
@@ -78,6 +78,11 @@ class SearchesController extends Controller
             'query' => 'required|string|min:1|max:2048',
         ]);
 
+        $listExists = DB::table('searches')->where([
+            'guid' => $user->getId(),
+            'list' => $listName,
+        ])->count() > 0;
+
         DB::table('searches')
             ->updateOrInsert(
                 [
@@ -94,7 +99,7 @@ class SearchesController extends Controller
                 ]
             );
 
-        if (DB::table('searches')->where('list', '=', $listName)->get(['*'])->count() == 1) {
+        if (!$listExists) {
             event(new ListCreated($user, $listName));
         }
 


### PR DESCRIPTION
Fix memory consumption of addSearch by not fetching the entire database.
Fire ListCreated event if the list is "created" for the user, not globally.
Only fire SearchAdded when a new search is added, not when an existing one is changed.